### PR TITLE
Refine mobile toggle spacing and refresh theme icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,41 @@
                     <span class="sr-only">Toggle light and dark theme</span>
                     <span class="theme-toggle__track" aria-hidden="true">
                         <span class="theme-toggle__thumb"></span>
-                        <span class="theme-toggle__icon theme-toggle__icon--sun">☀️</span>
-                        <span class="theme-toggle__icon theme-toggle__icon--moon">🌙</span>
+                        <svg
+                            class="theme-toggle__icon theme-toggle__icon--sun"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                            focusable="false"
+                        >
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="4.75"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="1.8"
+                            />
+                            <path
+                                d="M12 3.2v2.2M12 18.6v2.2M3.2 12h2.2M18.6 12h2.2M5.8 5.8l1.55 1.55M16.65 16.65l1.55 1.55M5.8 18.2l1.55-1.55M16.65 7.35l1.55-1.55"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="1.8"
+                                stroke-linecap="round"
+                            />
+                        </svg>
+                        <svg
+                            class="theme-toggle__icon theme-toggle__icon--moon"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                            focusable="false"
+                        >
+                            <path
+                                d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                clip-rule="evenodd"
+                            />
+                        </svg>
                     </span>
                 </button>
             </div>
@@ -123,8 +156,41 @@
                 <span class="sr-only">Toggle light and dark theme</span>
                 <span class="theme-toggle__track" aria-hidden="true">
                     <span class="theme-toggle__thumb"></span>
-                    <span class="theme-toggle__icon theme-toggle__icon--sun">☀️</span>
-                    <span class="theme-toggle__icon theme-toggle__icon--moon">🌙</span>
+                    <svg
+                        class="theme-toggle__icon theme-toggle__icon--sun"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <circle
+                            cx="12"
+                            cy="12"
+                            r="4.75"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="1.8"
+                        />
+                        <path
+                            d="M12 3.2v2.2M12 18.6v2.2M3.2 12h2.2M18.6 12h2.2M5.8 5.8l1.55 1.55M16.65 16.65l1.55 1.55M5.8 18.2l1.55-1.55M16.65 7.35l1.55-1.55"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="1.8"
+                            stroke-linecap="round"
+                        />
+                    </svg>
+                    <svg
+                        class="theme-toggle__icon theme-toggle__icon--moon"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <path
+                            d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            clip-rule="evenodd"
+                        />
+                    </svg>
                 </span>
             </button>
         </div>

--- a/style.css
+++ b/style.css
@@ -172,28 +172,26 @@ header {
 }
 
 .theme-toggle--mobile {
-    width: 3.05rem;
-    height: 1.75rem;
-    opacity: 0.8;
+    width: 3.2rem;
+    height: 1.85rem;
+    opacity: 0.88;
+    --toggle-mobile-thumb-size: 1.12rem;
+    --toggle-mobile-track-padding: 0.34rem;
 }
 
 .theme-toggle--mobile .theme-toggle__track {
-    padding: 0 0.35rem;
+    padding: 0 var(--toggle-mobile-track-padding);
     box-shadow: 0 3px 10px var(--toggle-shadow);
 }
 
 .theme-toggle--mobile .theme-toggle__thumb {
-    width: 1.2rem;
-    height: 1.2rem;
-    left: 0.2rem;
+    width: var(--toggle-mobile-thumb-size);
+    height: var(--toggle-mobile-thumb-size);
+    left: var(--toggle-mobile-track-padding);
 }
 
 .theme-toggle--mobile.theme-toggle--dark .theme-toggle__thumb {
-    left: calc(100% - 1.4rem);
-}
-
-.theme-toggle--mobile .theme-toggle__icon {
-    font-size: 0.85rem;
+    left: calc(100% - var(--toggle-mobile-thumb-size) - var(--toggle-mobile-track-padding));
 }
 
 .theme-toggle:hover {
@@ -236,8 +234,10 @@ header {
 }
 
 .theme-toggle__icon {
-    font-size: 0.95rem;
-    line-height: 1;
+    width: 1.1rem;
+    height: 1.1rem;
+    display: block;
+    flex-shrink: 0;
     color: var(--toggle-icon-muted);
     opacity: 0.65;
     transition: color 0.3s ease, opacity 0.3s ease;


### PR DESCRIPTION
## Summary
- refine the mobile theme toggle dimensions with CSS variables so the thumb sits evenly within the track
- replace the emoji sun/moon with simple inline SVG icons that leave transparent gaps to blend with the background

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3abe6bb3c832d844ed54281f3a279